### PR TITLE
Refactor listen store

### DIFF
--- a/listen2gether.nimble
+++ b/listen2gether.nimble
@@ -16,6 +16,7 @@ requires "nodejs"
 requires "https://gitlab.com/tandy1000/listenbrainz-nim#head"
 requires "https://gitlab.com/tandy1000/lastfm-nim#refactor"
 requires "jsony"
+requires "stew"
 requires "karax"
 
 task docs, "Generate docs":

--- a/listen2gether.nimble
+++ b/listen2gether.nimble
@@ -16,7 +16,6 @@ requires "nodejs"
 requires "https://gitlab.com/tandy1000/listenbrainz-nim#head"
 requires "https://gitlab.com/tandy1000/lastfm-nim#refactor"
 requires "jsony"
-requires "stew"
 requires "karax"
 
 task docs, "Generate docs":

--- a/src/client.nim
+++ b/src/client.nim
@@ -1,3 +1,7 @@
+## Client module
+## This module is where the web app is rendered.
+##
+
 import
   std/[dom, strutils],
   pkg/karax/[karax, karaxdsl, vdom, localstorage, jstrutils],

--- a/src/server.nim
+++ b/src/server.nim
@@ -1,3 +1,7 @@
+## Server module
+## The development server for the web app.
+##
+
 import
   pkg/prologue,
   pkg/prologue/middlewares/staticfile

--- a/src/sources/lb.nim
+++ b/src/sources/lb.nim
@@ -122,7 +122,7 @@ proc updateUser*(lb: AsyncListenBrainz, user: User, resetLastUpdate, preMirror =
     updatedUser.listenHistory = listenHistory & user.listenHistory
   return updatedUser
 
-proc pageUser*(lb: AsyncListenBrainz, user: var User, endInd: var int, `inc`: int = 10) {.async.} =
+proc pageUser*(lb: AsyncListenBrainz, user: var User, endInd: var int, `inc` = 10) {.async.} =
   ## Backfills ListenBrainz user's recent tracks
   let
     maxTs = get user.listenHistory[^1].listenedAt

--- a/src/sources/lb.nim
+++ b/src/sources/lb.nim
@@ -4,7 +4,7 @@ else:
   import std/asyncdispatch
 
 import
-  std/[times, strutils, unicode],
+  std/[times, strutils, unicode, sugar],
   pkg/[listenbrainz, union],
   pkg/listenbrainz/utils/api,
   pkg/listenbrainz/core,
@@ -28,17 +28,13 @@ proc to(track: Listen): APIListen =
                                     additionalInfo = some additionalInfo)
   result = newAPIListen(listenedAt = track.listenedAt, trackMetadata = trackMetadata)
 
-proc to(tracks: seq[Listen], toMirror = false): seq[APIListen] =
+proc to(tracks: seq[Listen]): seq[APIListen] =
   ## Convert a sequence of `Listen` objects to a sequence of `APIListen` objects.
-  ## When `toMirror` is set, only tracks that have not been mirrored or are not pre-mirror are returned.
-  for track in tracks:
-    if toMirror:
-      if not get(track.mirrored) and not get(track.preMirror):
-        result.add to track
-    else:
-      result.add to track
+  result = collect:
+    for track in tracks:
+      to track
 
-proc to(listen: APIListen, preMirror, mirrored: Option[bool] = none(bool)): Listen =
+proc to(listen: APIListen): Listen =
   ## Convert an `APIListen` object to a `Listen` object.
   result = newListen(trackName = cstring listen.trackMetadata.trackName,
                     artistName = cstring listen.trackMetadata.artistName,
@@ -47,23 +43,22 @@ proc to(listen: APIListen, preMirror, mirrored: Option[bool] = none(bool)): List
                     releaseMbid = to get(listen.trackMetadata.additionalInfo, AdditionalInfo()).releaseMbid,
                     artistMbids = to get(listen.trackMetadata.additionalInfo, AdditionalInfo()).artistMbids,
                     trackNumber = unionToInt get(listen.trackMetadata.additionalInfo, AdditionalInfo()).tracknumber,
-                    listenedAt = listen.listenedAt,
-                    preMirror = preMirror,
-                    mirrored = mirrored)
+                    listenedAt = listen.listenedAt)
 
-proc to(listens: seq[APIListen], preMirror, mirrored: Option[bool] = none(bool)): seq[Listen] =
+proc to(listens: seq[APIListen]): seq[Listen] =
   ## Convert a sequence of `APIListen` objects to a sequence of `Listen` objects
-  for listen in listens:
-    result.add to(listen, preMirror, mirrored)
+  result = collect:
+    for listen in listens:
+      to listen
 
-proc getNowPlaying(lb: AsyncListenBrainz, username: cstring, preMirror: bool): Future[Option[Listen]] {.async.} =
+proc getNowPlaying(lb: AsyncListenBrainz, username: cstring): Future[Option[Listen]] {.async.} =
   ## Return a ListenBrainz user's now playing
   try:
     let
       nowPlaying = await lb.getUserPlayingNow($username)
       payload = nowPlaying.payload
     if payload.count == 1:
-      return some to(payload.listens[0], preMirror = some preMirror, mirrored = some false)
+      return some to(payload.listens[0])
     else:
       return none Listen
   except JsonError:
@@ -71,86 +66,82 @@ proc getNowPlaying(lb: AsyncListenBrainz, username: cstring, preMirror: bool): F
   except HttpRequestError:
     logError("There was a problem getting $#'s now playing!" % $username)
 
-proc getRecentTracks(lb: AsyncListenBrainz, username: cstring, preMirror: bool, maxTs, minTs: int = 0, count: int = 100): Future[seq[Listen]] {.async.} =
+proc getRecentTracks(lb: AsyncListenBrainz, username: cstring, maxTs, minTs: int = 0, count: int = 100): Future[seq[Listen]] {.async.} =
   ## Return a ListenBrainz user's listen history
   try:
     let userListens = await lb.getUserListens($username, minTs, maxTs, count)
-    return to(userListens.payload.listens, some preMirror, some false)
+    return to(userListens.payload.listens)
   except JsonError:
     logError("There was a problem parsing $#'s listens!" % $username)
   except HttpRequestError:
     logError("There was a problem getting $#'s listens!" % $username)
 
-proc initUser*(lb: AsyncListenBrainz, username: cstring, token: cstring = "", selected = false): Future[User] {.async.} =
+proc initUser*(lb: AsyncListenBrainz, username: cstring, token: cstring = ""): Future[User] {.async.} =
   ## Gets a given ListenBrainz user's now playing, recent tracks, and latest listen timestamp.
   ## Returns a `User` object
   let username = cstring toLower($username)
-  var user = newUser(username, Service.listenBrainzService, token, selected = selected)
+  var user = newUser(username, Service.listenBrainzService, token)
   user.lastUpdateTs = int toUnix getTime()
-  user.playingNow = await lb.getNowPlaying(username, preMirror = true)
-  user.listenHistory = await lb.getRecentTracks(username, preMirror = true)
+  user.playingNow = await lb.getNowPlaying(username)
+  user.listenHistory = await lb.getRecentTracks(username)
   return user
 
-proc updateUser*(lb: AsyncListenBrainz, user: User, resetLastUpdate, preMirror = false): Future[User] {.async.} =
-  ## Updates ListenBrainz user's now playing, recent tracks, and latest listen timestamp
-  var updatedUser = user
+proc updateUser*(lb: AsyncListenBrainz, user: User, resetLastUpdate = false): Future[User] {.async.} =
+  ## Updates ListenBrainz user's history.
+
+  result = user
   if resetLastUpdate or user.listenHistory.len > 0:
-    updatedUser.lastUpdateTs = get user.listenHistory[0].listenedAt
+    result.lastUpdateTs = get user.listenHistory[0].listenedAt
   else:
-    updatedUser.lastUpdateTs = int toUnix getTime()
+    result.lastUpdateTs = int toUnix getTime()
 
   if resetLastUpdate:
     let
-      latestListenHistory = await lb.getRecentTracks(user.username, preMirror)
+      latestListenHistory = await lb.getRecentTracks(user.username)
       maxTs = get latestListenHistory[^1].listenedAt
 
-    if maxTs > updatedUser.lastUpdateTs: # fills in any gaps in history
-      var listenHistory = await lb.getRecentTracks(user.username, preMirror, minTs = updatedUser.lastUpdateTs, maxTs = maxTs)
-      updatedUser.listenHistory = listenHistory & user.listenHistory
+    if maxTs > result.lastUpdateTs: # fills in any gaps in history
+      var listenHistory = await lb.getRecentTracks(user.username, minTs = result.lastUpdateTs, maxTs = maxTs)
+      result.listenHistory = listenHistory & user.listenHistory
       while listenHistory.len > 0:
-        listenHistory = await lb.getRecentTracks(user.username, preMirror, minTs = updatedUser.lastUpdateTs, maxTs = maxTs)
-        updatedUser.listenHistory = listenHistory & updatedUser.listenHistory
-      updatedUser.playingNow = await lb.getNowPlaying(user.username, preMirror)
-      updatedUser.listenHistory = latestListenHistory & updatedUser.listenHistory
+        listenHistory = await lb.getRecentTracks(user.username, minTs = result.lastUpdateTs, maxTs = maxTs)
+        result.listenHistory = listenHistory & result.listenHistory
+      result.playingNow = await lb.getNowPlaying(user.username)
+      result.listenHistory = latestListenHistory & result.listenHistory
     else: # no gap / overlap
-      updatedUser.playingNow = await lb.getNowPlaying(user.username, preMirror)
-      let listenHistory = await lb.getRecentTracks(user.username, preMirror, minTs = updatedUser.lastUpdateTs)
-      updatedUser.listenHistory = listenHistory & user.listenHistory
+      result.playingNow = await lb.getNowPlaying(user.username)
+      let listenHistory = await lb.getRecentTracks(user.username, minTs = result.lastUpdateTs)
+      result.listenHistory = listenHistory & user.listenHistory
   else:
-    updatedUser.playingNow = await lb.getNowPlaying(user.username, preMirror)
-    let listenHistory = await lb.getRecentTracks(user.username, preMirror, minTs = user.lastUpdateTs)
-    updatedUser.listenHistory = listenHistory & user.listenHistory
-  return updatedUser
+    result.playingNow = await lb.getNowPlaying(user.username)
+    let listenHistory = await lb.getRecentTracks(user.username, minTs = user.lastUpdateTs)
+    result.listenHistory = listenHistory & user.listenHistory
 
 proc pageUser*(lb: AsyncListenBrainz, user: var User, endInd: var int, `inc` = 10) {.async.} =
   ## Backfills ListenBrainz user's recent tracks
   let
     maxTs = get user.listenHistory[^1].listenedAt
-    newTracks = await lb.getRecentTracks(user.username, preMirror = true, maxTs = maxTs)
+    newTracks = await lb.getRecentTracks(user.username, maxTs = maxTs)
   user.listenHistory = user.listenHistory & newTracks
   endInd += `inc`
 
 proc submitMirrorQueue*(lb: AsyncListenBrainz, user: var User) {.async.} =
-  ## Submits ListenBrainz user's now playing and listen history that are not `mirrored` or `preMirror`
-  if isSome user.playingNow:
-    if not get(get(user.playingNow).preMirror) and not get(get(user.playingNow).mirrored):
-      let
-        listen = to get user.playingNow
-        playingNow = newSubmitListens(listenType = ListenType.playingNow, @[listen])
-      try:
-        discard lb.submitListens(playingNow)
-        get(user.playingNow).mirrored = some true
-      except HttpRequestError:
-        logError("There was a problem submitting your now playing!")
-
-  let listens = to(user.listenHistory, toMirror = true)
-  if listens.len > 0:
+  ## Submits ListenBrainz user's mirror queue including playing now, and updates the `lastSubmissionTs`.
+  if user.submitQueue.playingNow.isSome():
+    let
+      listen = to get user.playingNow
+      playingNow = newSubmitListens(listenType = ListenType.playingNow, @[listen])
     try:
-      let payload = newSubmitListens(listenType = ListenType.import, listens)
-      discard lb.submitListens(payload)
-      let mirroredTracks = to listens
-      for idx, track in user.listenHistory[0..^1]:
-        if track in mirroredTracks:
-          user.listenHistory[idx].mirrored = some true
+      discard lb.submitListens(playingNow)
+      user.submitQueue.playingNow = none Listen
     except HttpRequestError:
-      logError("There was a problem submitting your listens!")
+      logError("There was a problem submitting your now playing!")
+  else:
+    if user.submitQueue.listens.len > 0:
+      try:
+        let payload = newSubmitListens(listenType = ListenType.import, to(user.submitQueue.listens))
+        discard lb.submitListens(payload)
+        user.lastSubmissionTs = user.submitQueue.listens[0].listenedAt
+        user.submitQueue.listens = @[]
+      except HttpRequestError:
+        logError("There was a problem submitting your listens!")

--- a/src/sources/lb.nim
+++ b/src/sources/lb.nim
@@ -1,3 +1,7 @@
+## ListenBrainz module
+## This contains support for the ListenBrainz backend.
+##
+
 when defined(js):
   import std/asyncjs
 else:

--- a/src/sources/lfm.nim
+++ b/src/sources/lfm.nim
@@ -244,7 +244,7 @@ proc updateUser*(fm: AsyncLastFM, user: User, resetLastUpdate, preMirror = false
     updatedUser.listenHistory = listenHistory & user.listenHistory
   return updatedUser
 
-proc pageUser*(fm: AsyncLastFM, user: var User, endInd: var int, `inc`: int = 10) {.async.} =
+proc pageUser*(fm: AsyncLastFM, user: var User, endInd: var int, `inc` = 10) {.async.} =
   ## Backfills Last.fm user's recent tracks
   let
     to = get user.listenHistory[^1].listenedAt

--- a/src/sources/lfm.nim
+++ b/src/sources/lfm.nim
@@ -1,3 +1,7 @@
+## Last.fm module
+## This contains support for the Last.fm backend.
+##
+
 when defined(js):
   import std/asyncjs
 else:

--- a/src/sources/lfm.nim
+++ b/src/sources/lfm.nim
@@ -4,10 +4,10 @@ else:
   import std/asyncdispatch
 
 import
-  std/[json, options, strutils, times, unicode],
+  std/[json, options, strutils, times, unicode, sugar],
   pkg/[jsony, lastfm],
   pkg/lastfm/[track, user],
-  types, utils
+  types, utils, pure
 
 const
   userBaseUrl*: cstring = "https://last.fm/user/"
@@ -105,14 +105,13 @@ func to(fmTrack: FMTrack, preMirror, mirrored: Option[bool] = none(bool)): Liste
                     recordingMbid = to fmTrack.mbid,
                     releaseMbid = getVal(fmTrack.album, "mbid"),
                     artistMbids = parseMbids getStr fmTrack.artist{"mbid"},
-                    listenedAt = parseDate fmTrack.date,
-                    preMirror = preMirror,
-                    mirrored = mirrored)
+                    listenedAt = parseDate fmTrack.date)
 
-func to(fmTracks: seq[FMTrack], preMirror, mirrored: Option[bool] = none(bool)): seq[Listen] =
+func to(fmTracks: seq[FMTrack]): seq[Listen] =
   ## Convert a sequence of `FMTrack` objects to a sequence of `Listen` objects
-  for fmTrack in fmTracks:
-    result.add to(fmTrack, preMirror, mirrored)
+  result = collect:
+    for fmTrack in fmTracks:
+      to(fmTrack)
 
 func to(scrobble: Scrobble, preMirror, mirrored: Option[bool] = none(bool)): Listen =
   ## Convert a `Scrobble` object to a `Listen` object
@@ -121,14 +120,13 @@ func to(scrobble: Scrobble, preMirror, mirrored: Option[bool] = none(bool)): Lis
                     releaseName = to scrobble.album,
                     recordingMbid = to scrobble.mbid,
                     trackNumber = scrobble.trackNumber,
-                    listenedAt = scrobble.timestamp,
-                    preMirror = preMirror,
-                    mirrored = mirrored)
+                    listenedAt = scrobble.timestamp)
 
-func to(listens: seq[Scrobble], preMirror, mirrored: Option[bool] = none(bool)): seq[Listen] =
+func to(listens: seq[Scrobble]): seq[Listen] =
   ## Convert a sequence of `Scrobble` objects to a sequence of `Listen` objects
-  for listen in listens:
-    result.add to(listen, preMirror, mirrored)
+  result = collect:
+    for listen in listens:
+      to(listen)
 
 func to(listen: Listen): Scrobble =
   ## Convert a `Listen` object to a `Scrobble` object
@@ -140,15 +138,11 @@ func to(listen: Listen): Scrobble =
                       albumArtist = some $listen.artistName,
                       trackNumber = listen.trackNumber)
 
-func to(tracks: seq[Listen], toMirror = false): seq[Scrobble] =
+func to(tracks: seq[Listen]): seq[Scrobble] =
   ## Convert a sequence of `Listen` objects to a sequence of `Scrobble` objects.
-  ## When `toMirror` is set, only tracks that have not been mirrored or are not pre-mirror are returned.
-  for track in tracks:
-    if toMirror:
-      if not get(track.mirrored) and not get(track.preMirror):
-        result.add to track
-    else:
-      result.add to track
+  result = collect:
+    for track in tracks:
+      to(track)
 
 proc setNowPlayingTrack(fm: AsyncLastFM, scrobble: Scrobble): Future[JsonNode] {.async.} =
   ## Sets the current playing track on Last.fm
@@ -179,11 +173,11 @@ proc scrobbleTrack(fm: AsyncLastFM, scrobble: Scrobble): Future[JsonNode] {.asyn
 
 proc scrobbleTracks(fm: AsyncLastFM, scrobbles: seq[Scrobble]): Future[seq[JsonNode]] {.async.} =
   ## Scrobble many tracks to Last.fm
-  var futures: seq[JsonNode]
-  for scrobble in scrobbles:
-    futures.add await fm.scrobbleTrack(scrobble)
+  result = collect:
+    for scrobble in scrobbles:
+      await fm.scrobbleTrack(scrobble)
 
-proc getRecentTracks(fm: AsyncLastFM, username: cstring, preMirror: bool, `from`, upTo = 0, limit = 100): Future[(Option[Listen], seq[Listen])] {.async.} =
+proc getRecentTracks(fm: AsyncLastFM, username: cstring, `from`, upTo = 0, limit = 100): Future[(Option[Listen], seq[Listen])] {.async.} =
   ## Return a Last.FM user's listen history and now playing
   var
     playingNow: Option[Listen]
@@ -193,11 +187,10 @@ proc getRecentTracks(fm: AsyncLastFM, username: cstring, preMirror: bool, `from`
       recentTracks = await fm.userRecentTracks(user = $username, limit = limit, `from` = `from`, to = upTo)
       tracks = recentTracks["recenttracks"]["track"]
     if tracks.len == limit:
-      listenHistory = to(fromJson($tracks, seq[FMTrack]), preMirror = some preMirror, mirrored = some false)
+      listenHistory = to(fromJson($tracks, seq[FMTrack]))
     elif tracks.len == limit+1:
-      playingNow = some to(fromJson($tracks[0], FMTrack), preMirror = some preMirror)
-      # potential speedup: tracks[1..^1].mapIt(it.to(FMTrack))
-      listenHistory = to(fromJson($tracks[1..^1], seq[FMTrack]), preMirror = some preMirror, mirrored = some false)
+      playingNow = some to(fromJson($tracks[0], FMTrack))
+      listenHistory = to(fromJson($tracks[1..^1], seq[FMTrack]))
     return (playingNow, listenHistory)
   except HttpRequestError:
     logError "There was a problem getting " & $username & "'s listens!"
@@ -206,69 +199,64 @@ proc initUser*(fm: AsyncLastFM, username: cstring, sessionKey: cstring = "", sel
   ## Gets a given Last.fm user's now playing, recent tracks, and latest listen timestamp.
   ## Returns a `User` object
   let username = cstring toLower($username)
-  var user = newUser(username, Service.lastFmService, sessionKey = sessionKey, selected = selected)
-  user.lastUpdateTs = int toUnix getTime()
-  let (playingNow, listenHistory) = await fm.getRecentTracks(username, preMirror = true)
-  user.playingNow = playingNow
-  user.listenHistory = listenHistory
-  return user
+  result = newUser(username, Service.lastFmService, sessionKey = sessionKey)
+  result.lastUpdateTs = int toUnix getTime()
+  let (playingNow, listenHistory) = await fm.getRecentTracks(username)
+  result.playingNow = playingNow
+  result.listenHistory = listenHistory
 
-proc updateUser*(fm: AsyncLastFM, user: User, resetLastUpdate, preMirror = false): Future[User] {.async.} =
+proc updateUser*(fm: AsyncLastFM, user: User, resetLastUpdate = false): Future[User] {.async.} =
   ## Updates Last.fm user's now playing, recent tracks, and latest listen timestamp
-  var updatedUser = user
+
+  result = user
   if resetLastUpdate or user.listenHistory.len > 0:
-    updatedUser.lastUpdateTs = get user.listenHistory[0].listenedAt
+    result.lastUpdateTs = get user.listenHistory[0].listenedAt
   else:
-    updatedUser.lastUpdateTs = int toUnix getTime()
+    result.lastUpdateTs = int toUnix getTime()
 
   if resetLastUpdate:
     let
-      (_, latestListenHistory) = await fm.getRecentTracks(user.username, preMirror)
+      (_, latestListenHistory) = await fm.getRecentTracks(user.username)
       upTo = get latestListenHistory[^1].listenedAt
 
-    if upTo > updatedUser.lastUpdateTs: # fills in any gaps in history
-      var (playingNow, listenHistory) = await fm.getRecentTracks(user.username, preMirror, `from` = user.lastUpdateTs, upTo = upTo)
-      updatedUser.listenHistory = listenHistory & user.listenHistory
+    if upTo > result.lastUpdateTs: # fills in any gaps in history
+      var (playingNow, listenHistory) = await fm.getRecentTracks(user.username, `from` = user.lastUpdateTs, upTo = upTo)
+      result.listenHistory = listenHistory & user.listenHistory
       while listenHistory.len > 0:
-        (playingNow, listenHistory) = await fm.getRecentTracks(user.username, preMirror, `from` = user.lastUpdateTs, upTo = upTo)
-        updatedUser.listenHistory = listenHistory & updatedUser.listenHistory
-      updatedUser.playingNow = playingNow
-      updatedUser.listenHistory = latestListenHistory & updatedUser.listenHistory
+        (playingNow, listenHistory) = await fm.getRecentTracks(user.username, `from` = user.lastUpdateTs, upTo = upTo)
+        result.listenHistory = listenHistory & result.listenHistory
+      result.playingNow = playingNow
+      result.listenHistory = latestListenHistory & result.listenHistory
     else: # no gap / overlap
-      let (playingNow, listenHistory) = await fm.getRecentTracks(user.username, preMirror, `from` = updatedUser.lastUpdateTs)
-      updatedUser.playingNow = playingNow
-      updatedUser.listenHistory = listenHistory & user.listenHistory
+      let (playingNow, listenHistory) = await fm.getRecentTracks(user.username, `from` = result.lastUpdateTs)
+      result.playingNow = playingNow
+      result.listenHistory = listenHistory & user.listenHistory
   else:
-    let (playingNow, listenHistory) = await fm.getRecentTracks(user.username, preMirror, `from` = user.lastUpdateTs)
-    updatedUser.playingNow = playingNow
-    updatedUser.listenHistory = listenHistory & user.listenHistory
-  return updatedUser
+    let (playingNow, listenHistory) = await fm.getRecentTracks(user.username, `from` = user.lastUpdateTs)
+    result.playingNow = playingNow
+    result.listenHistory = listenHistory & user.listenHistory
 
 proc pageUser*(fm: AsyncLastFM, user: var User, endInd: var int, `inc` = 10) {.async.} =
   ## Backfills Last.fm user's recent tracks
   let
     to = get user.listenHistory[^1].listenedAt
-    (playingNow, listenHistory) = await fm.getRecentTracks(user.username, preMirror = true, upTo = to)
+    (playingNow, listenHistory) = await fm.getRecentTracks(user.username, upTo = to)
   user.playingNow = playingNow
   user.listenHistory = user.listenHistory & listenHistory
   endInd += `inc`
 
 proc submitMirrorQueue*(fm: AsyncLastFM, user: var User) {.async.} =
   ## Submits Last.fm user's now playing and listen history that are not mirrored or preMirror
-  if isSome user.playingNow:
-    if not get(get(user.playingNow).preMirror) and not get(get(user.playingNow).mirrored):
-      try:
-        discard fm.setNowPlayingTrack(to get user.playingNow)
-      except:
-        logError "There was a problem submitting your now playing!"
-
-  let scrobbles = to(user.listenHistory, toMirror = true)
-  if scrobbles.len > 0:
+  if user.submitQueue.playingNow.isSome():
+    try:
+      discard fm.setNowPlayingTrack(to get user.playingNow)
+      user.submitQueue.playingNow = none Listen
+    except HttpRequestError:
+      logError("There was a problem submitting your now playing!")
+  if user.submitQueue.listens.len > 0:
     try:
       discard fm.scrobbleTracks scrobbles
-      let mirroredTracks = to scrobbles
-      for idx, track in user.listenHistory[0..^1]:
-        if track in mirroredTracks:
-          user.listenHistory[idx].mirrored = some true
+      user.lastSubmissionTs = user.submitQueue.listens[0].listenedAt
+      user.submitQueue.listens = @[]
     except:
       logError "There was a problem submitting your scrobbles!"

--- a/src/sources/lfm.nim
+++ b/src/sources/lfm.nim
@@ -255,7 +255,7 @@ proc submitMirrorQueue*(fm: AsyncLastFM, user: var User) {.async.} =
       logError("There was a problem submitting your now playing!")
   if user.submitQueue.listens.len > 0:
     try:
-      discard fm.scrobbleTracks scrobbles
+      discard fm.scrobbleTracks to(user.submitQueue.listens)
       user.lastSubmissionTs = user.submitQueue.listens[0].listenedAt
       user.submitQueue.listens = @[]
     except:

--- a/src/sources/lfm.nim
+++ b/src/sources/lfm.nim
@@ -97,7 +97,7 @@ func parseMbids(mbid: string): Option[seq[cstring]] =
   else:
     result = some @[cstring mbid]
 
-func to(fmTrack: FMTrack, preMirror, mirrored: Option[bool] = none(bool)): Listen =
+func to(fmTrack: FMTrack): Listen =
   ## Convert an `FMTrack` object to a `Listen` object
   result = newListen(trackName = cstring get fmTrack.name,
                     artistName = get getVal(fmTrack.artist, "#text"),
@@ -113,7 +113,7 @@ func to(fmTracks: seq[FMTrack]): seq[Listen] =
     for fmTrack in fmTracks:
       to(fmTrack)
 
-func to(scrobble: Scrobble, preMirror, mirrored: Option[bool] = none(bool)): Listen =
+func to(scrobble: Scrobble): Listen =
   ## Convert a `Scrobble` object to a `Listen` object
   result = newListen(trackName = cstring scrobble.track,
                     artistName = cstring scrobble.artist,
@@ -246,7 +246,7 @@ proc pageUser*(fm: AsyncLastFM, user: var User, endInd: var int, `inc` = 10) {.a
   endInd += `inc`
 
 proc submitMirrorQueue*(fm: AsyncLastFM, user: var User) {.async.} =
-  ## Submits Last.fm user's now playing and listen history that are not mirrored or preMirror
+  ## Submits Last.fm user's now playing and listen history
   if user.submitQueue.playingNow.isSome():
     try:
       discard fm.setNowPlayingTrack(to get user.playingNow)

--- a/src/sources/pure.nim
+++ b/src/sources/pure.nim
@@ -2,7 +2,7 @@ import
   std/[sugar, options],
   types
 
-proc queueFilter(
+proc queueFilter*(
   listen: Listen,
   latestListenTs, lastSubmissionTs: Option[int]): bool =
   ## Returns true when a Listen is either newer than `latestListenTs` or `lastSubmissionTs`.
@@ -14,13 +14,22 @@ proc queueFilter(
     if lastSubmissionTs.isSome():
       if listenedAt > get(lastSubmissionTs):
         result = true
+      else:
+        result = false
+  else:
+    raise newException(IOError, "Listen has no listenedAt property!")
+
+proc updateQueue*(user: User, mirror: User): seq[Listen] =
+  ## Updates the `submitQueue` for a user given a mirror user.
+  result = collect():
+    for listen in mirror.listenHistory:
+      if queueFilter(listen, user.listenHistory[0].listenedAt, user.lastSubmissionTs):
+        listen
 
 proc updateQueue*(users: seq[User], mirror: User): seq[User] =
   ## Updates the `submitQueue` for all users in `seq[User]`, given a mirror user.
-  for user in users:
-    var updatedUser = user
-    updatedUser.submitQueue.listens = collect(newSeq):
-      for listen in mirror.listenHistory:
-        if queueFilter(listen, updatedUser.listenHistory[0].listenedAt, updatedUser.lastSubmissionTs):
-          listen
-    result.add updatedUser
+  result = collect():
+    for user in users:
+      var updatedUser = user
+      updatedUser.submitQueue.listens = updateQueue(user, mirror)
+      updatedUser

--- a/src/sources/pure.nim
+++ b/src/sources/pure.nim
@@ -1,3 +1,7 @@
+## Pure module
+## Listen tracking source agnostic functions.
+##
+
 import
   std/[sugar, options],
   types

--- a/src/sources/pure.nim
+++ b/src/sources/pure.nim
@@ -1,0 +1,27 @@
+import
+  std/[sugar, options],
+  types
+
+proc queueFilter(
+  listen: Listen,
+  lastUpdateTs: int,
+  lastSubmissionTs: Option[int]): bool =
+  ## Returns true when a Listen is either newer than `lastUpdateTs` or `lastSubmissionTs`.
+  if listen.listenedAt.isSome():
+    let listenedAt = get(listen.listenedAt)
+    if listenedAt > lastUpdateTs:
+      result = true
+    if lastSubmissionTs.isSome():
+      if listenedAt > get(lastSubmissionTs):
+        result = true
+
+proc updateQueue*(users: seq[User], mirror: User): seq[User] =
+  ## Updates the `submitQueue` for all users in `seq[User]`, given a mirror user.
+  for user in users:
+    var updatedUser = user
+    let queue = collect(newSeq):
+      for listen in mirror.listenHistory:
+        if queueFilter(listen, updatedUser.lastUpdateTs, updatedUser.lastSubmissionTs):
+          listen
+    updatedUser.submitQueue.listens = queue
+    result.add updatedUser

--- a/src/sources/pure.nim
+++ b/src/sources/pure.nim
@@ -4,13 +4,13 @@ import
 
 proc queueFilter(
   listen: Listen,
-  lastUpdateTs: int,
-  lastSubmissionTs: Option[int]): bool =
-  ## Returns true when a Listen is either newer than `lastUpdateTs` or `lastSubmissionTs`.
+  latestListenTs, lastSubmissionTs: Option[int]): bool =
+  ## Returns true when a Listen is either newer than `latestListenTs` or `lastSubmissionTs`.
   if listen.listenedAt.isSome():
     let listenedAt = get(listen.listenedAt)
-    if listenedAt > lastUpdateTs:
-      result = true
+    if latestListenTs.isSome():
+      if listenedAt > get(latestListenTs):
+        result = true
     if lastSubmissionTs.isSome():
       if listenedAt > get(lastSubmissionTs):
         result = true
@@ -19,9 +19,8 @@ proc updateQueue*(users: seq[User], mirror: User): seq[User] =
   ## Updates the `submitQueue` for all users in `seq[User]`, given a mirror user.
   for user in users:
     var updatedUser = user
-    let queue = collect(newSeq):
+    updatedUser.submitQueue.listens = collect(newSeq):
       for listen in mirror.listenHistory:
-        if queueFilter(listen, updatedUser.lastUpdateTs, updatedUser.lastSubmissionTs):
+        if queueFilter(listen, updatedUser.listenHistory[0].listenedAt, updatedUser.lastSubmissionTs):
           listen
-    updatedUser.submitQueue.listens = queue
     result.add updatedUser

--- a/src/sources/utils.nim
+++ b/src/sources/utils.nim
@@ -1,3 +1,7 @@
+## Utilities module
+## Shared helper functions for listen tracking sources.
+##
+
 when defined(js):
   import std/jsconsole
 import

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,13 +1,14 @@
 import std/options
 
 type
+  Client* = ref object
+    users*: seq[cstring]
+    mirror*: Option[cstring]
+    startTs*: Option[int]
+
   Service* = enum
     listenBrainzService = "listenbrainz",
     lastFmService = "lastfm"
-
-  ListenQueue* = ref object
-    listens*: seq[Listen]
-    playingNow*: Option[Listen]
 
   User* = ref object
     userId*, username*: cstring
@@ -17,7 +18,6 @@ type
     of lastFmService:
       sessionKey*: cstring
     lastUpdateTs*: int
-    selected*: bool
     playingNow*: Option[Listen]
     listenHistory*: seq[Listen]
     submitQueue*: ListenQueue
@@ -28,6 +28,19 @@ type
     artistMbids*: Option[seq[cstring]]
     trackNumber*, listenedAt*: Option[int]
     playingNow*: Option[bool]
+
+  ListenQueue* = ref object
+    listens*: seq[Listen]
+    playingNow*: Option[Listen]
+
+func newClient*(
+  users: seq[cstring] = @[],
+  mirror: Option[cstring] = none(cstring),
+  startTs: Option[int] = none(int)): Client =
+  result = Client()
+  result.users = users
+  result.mirror = mirror
+  result.startTs = startTs
 
 func newListenQueue*(
   listens: seq[Listen] = @[],
@@ -41,7 +54,6 @@ func newUser*(
   service: Service,
   token, sessionKey: cstring = "",
   lastUpdateTs: int = 0,
-  selected: bool = false,
   playingNow: Option[Listen] = none(Listen),
   listenHistory: seq[Listen] = @[],
   submitQueue: ListenQueue = newListenQueue()): User =
@@ -55,7 +67,6 @@ func newUser*(
   of lastFmService:
     result.sessionKey = sessionKey
   result.lastUpdateTs = lastUpdateTs
-  result.selected = selected
   result.playingNow = playingNow
   result.listenHistory = listenHistory
   result.submitQueue = submitQueue

--- a/src/types.nim
+++ b/src/types.nim
@@ -3,6 +3,7 @@ import std/options
 type
   Client* = ref object
     ## Stores client state, including a `seq` of user IDs, and optionally a mirror user ID.
+    clientId*: cstring
     users*: seq[cstring]
     mirror*: Option[cstring]
 
@@ -40,9 +41,11 @@ type
     playingNow*: Option[Listen]
 
 func newClient*(
+  clientId: cstring = "session",
   users: seq[cstring] = @[],
   mirror: Option[cstring] = none(cstring)): Client =
   result = Client()
+  result.clientId = clientId
   result.users = users
   result.mirror = mirror
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -23,7 +23,6 @@ type
     releaseName*, recordingMbid*, releaseMbid*: Option[cstring]
     artistMbids*: Option[seq[cstring]]
     trackNumber*, listenedAt*: Option[int]
-    mirrored*, preMirror*: Option[bool]
 
 func newUser*(
   username: cstring,
@@ -55,8 +54,7 @@ func newListen*(
   releaseName, recordingMbid, releaseMbid: Option[cstring] = none(cstring),
   artistMbids: Option[seq[cstring]] = none(seq[cstring]),
   trackNumber: Option[int] = none(int),
-  listenedAt: Option[int] = none(int),
-  mirrored, preMirror: Option[bool] = none(bool)): Listen =
+  listenedAt: Option[int] = none(int)): Listen =
   ## Create new Listen object
   result.trackName = trackName
   result.artistName = artistName
@@ -66,8 +64,6 @@ func newListen*(
   result.artistMbids = artistMbids
   result.trackNumber = trackNumber
   result.listenedAt = listenedAt
-  result.mirrored = mirrored
-  result.preMirror = preMirror
 
 func `==`*(a, b: Listen): bool =
   ## does not include `mirrored` or `preMirror`

--- a/src/types.nim
+++ b/src/types.nim
@@ -4,7 +4,6 @@ type
   Client* = ref object
     users*: seq[cstring]
     mirror*: Option[cstring]
-    startTs*: Option[int]
 
   Service* = enum
     listenBrainzService = "listenbrainz",
@@ -18,6 +17,7 @@ type
     of lastFmService:
       sessionKey*: cstring
     lastUpdateTs*: int
+    lastSubmissionTs*: Option[int]
     playingNow*: Option[Listen]
     listenHistory*: seq[Listen]
     submitQueue*: ListenQueue
@@ -35,12 +35,10 @@ type
 
 func newClient*(
   users: seq[cstring] = @[],
-  mirror: Option[cstring] = none(cstring),
-  startTs: Option[int] = none(int)): Client =
+  mirror: Option[cstring] = none(cstring)): Client =
   result = Client()
   result.users = users
   result.mirror = mirror
-  result.startTs = startTs
 
 func newListenQueue*(
   listens: seq[Listen] = @[],
@@ -54,6 +52,7 @@ func newUser*(
   service: Service,
   token, sessionKey: cstring = "",
   lastUpdateTs: int = 0,
+  lastSubmissionTs: Option[int] = none(int),
   playingNow: Option[Listen] = none(Listen),
   listenHistory: seq[Listen] = @[],
   submitQueue: ListenQueue = newListenQueue()): User =
@@ -67,6 +66,7 @@ func newUser*(
   of lastFmService:
     result.sessionKey = sessionKey
   result.lastUpdateTs = lastUpdateTs
+  result.lastSubmissionTs = lastSubmissionTs
   result.playingNow = playingNow
   result.listenHistory = listenHistory
   result.submitQueue = submitQueue

--- a/src/types.nim
+++ b/src/types.nim
@@ -2,14 +2,18 @@ import std/options
 
 type
   Client* = ref object
+    ## Stores client state, including a `seq` of user IDs, and optionally a mirror user ID.
     users*: seq[cstring]
     mirror*: Option[cstring]
 
   Service* = enum
+    ## Store the supported services, used to create object variants of `User`.
     listenBrainzService = "listenbrainz",
     lastFmService = "lastfm"
 
   User* = ref object
+    ## Stores a client user for the application.
+    ## The supported services include ListenBrainz and LastFM.
     userId*, username*: cstring
     case service*: Service
     of listenBrainzService:
@@ -22,7 +26,8 @@ type
     listenHistory*: seq[Listen]
     submitQueue*: ListenQueue
 
-  Listen* = object
+  Listen* = ref object
+    ## A normalised listen format used across the client.
     trackName*, artistName*: cstring
     releaseName*, recordingMbid*, releaseMbid*: Option[cstring]
     artistMbids*: Option[seq[cstring]]
@@ -30,6 +35,7 @@ type
     playingNow*: Option[bool]
 
   ListenQueue* = ref object
+    ## Stores the listens that need to be submitted by a user, including a playing now listen.
     listens*: seq[Listen]
     playingNow*: Option[Listen]
 
@@ -81,6 +87,7 @@ func newListen*(
   listenedAt: Option[int] = none(int),
   playingNow: Option[bool] = none(bool)): Listen =
   ## Create new Listen object
+  result = Listen()
   result.trackName = trackName
   result.artistName = artistName
   result.releaseName = releaseName

--- a/src/types.nim
+++ b/src/types.nim
@@ -3,7 +3,7 @@ import std/options
 type
   Client* = ref object
     ## Stores client state, including a `seq` of user IDs, and optionally a mirror user ID.
-    clientId*: cstring
+    id*: cstring
     users*: seq[cstring]
     mirror*: Option[cstring]
 
@@ -15,7 +15,7 @@ type
   User* = ref object
     ## Stores a client user for the application.
     ## The supported services include ListenBrainz and LastFM.
-    userId*, username*: cstring
+    id*, username*: cstring
     case service*: Service
     of listenBrainzService:
       token*: cstring
@@ -41,11 +41,11 @@ type
     playingNow*: Option[Listen]
 
 func newClient*(
-  clientId: cstring = "session",
+  id: cstring = "session",
   users: seq[cstring] = @[],
   mirror: Option[cstring] = none(cstring)): Client =
   result = Client()
-  result.clientId = clientId
+  result.id = id
   result.users = users
   result.mirror = mirror
 
@@ -67,7 +67,7 @@ func newUser*(
   submitQueue: ListenQueue = newListenQueue()): User =
   ## Create new User object
   result = User(service: service)
-  result.userId = cstring($service & ":" & $username)
+  result.id = cstring($service & ":" & $username)
   result.username = username
   case service:
   of listenBrainzService:
@@ -80,7 +80,7 @@ func newUser*(
   result.listenHistory = listenHistory
   result.submitQueue = submitQueue
 
-func `==`*(a, b: User): bool = a.userId == b.userId
+func `==`*(a, b: User): bool = a.id == b.id
 
 func newListen*(
   trackName, artistName: cstring,

--- a/src/types.nim
+++ b/src/types.nim
@@ -16,6 +16,7 @@ type
     selected*: bool
     playingNow*: Option[Listen]
     listenHistory*: seq[Listen]
+    submitQueue*: seq[Listen]
 
   Listen* = object
     trackName*, artistName*: cstring
@@ -31,7 +32,7 @@ func newUser*(
   lastUpdateTs: int = 0,
   selected: bool = false,
   playingNow: Option[Listen] = none(Listen),
-  listenHistory: seq[Listen] = @[]): User =
+  listenHistory, submitQueue: seq[Listen] = @[]): User =
   ## Create new User object
   result = User(service: service)
   result.userId = cstring($service & ":" & $username)
@@ -45,6 +46,7 @@ func newUser*(
   result.selected = selected
   result.playingNow = playingNow
   result.listenHistory = listenHistory
+  result.submitQueue = submitQueue
 
 func `==`*(a, b: User): bool = a.userId == b.userId
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,3 +1,7 @@
+## Types module
+## Where all the web app's types / data models are defined.
+##
+
 import std/options
 
 type

--- a/src/views/db.nim
+++ b/src/views/db.nim
@@ -1,0 +1,39 @@
+## Database module
+## The web app's database structure is as follows:
+## - Client table: stores one client object per session.
+## - User table: stores users used by a client object.
+##
+
+import
+  std/[asyncjs, jsffi, tables, sugar],
+  pkg/nodejs/jsindexeddb,
+  sources/utils,
+  types
+
+const
+  CLIENT_DB_STORE*: cstring = "clients"
+  USER_DB_STORE*: cstring = "users"
+
+var
+  db*: IndexedDB = newIndexedDB()
+  clients*: Table[cstring, Client] = initTable[cstring, Client]()
+  users*: Table[cstring, User] = initTable[cstring, User]()
+
+proc getTable*[T](db: IndexedDB, dbStore: cstring, dbOptions: IDBOptions): Future[Table[cstring, T]] {.async.} =
+  ## Gets objects from a given IndexedDB location and store in a Table.
+  result = initTable[cstring, T]()
+  try:
+    let objStore = await getAll(db, dbStore, dbOptions)
+    if not objStore.isNil:
+      result = collect:
+        for obj in to(objStore, seq[T]): {obj.id: obj}
+  except:
+    logError "Failed to get stored objects."
+
+proc storeUser*[T](db: IndexedDB, obj: T, objs: var Table[cstring, T], dbStore: cstring, dbOptions: IDBOptions) {.async.} =
+  ## Stores an object in a given store in IndexedDB.
+  objs[obj.id] = obj
+  try:
+    discard put(db, dbStore, toJs obj, dbOptions)
+  except:
+    logError "Failed to store object."

--- a/src/views/db.nim
+++ b/src/views/db.nim
@@ -12,6 +12,7 @@ import
 
 const
   CLIENT_DB_STORE*: cstring = "clients"
+  CLIENT_ID*: cstring = "session"
   USER_DB_STORE*: cstring = "users"
 
 var
@@ -19,7 +20,7 @@ var
   clients*: Table[cstring, Client] = initTable[cstring, Client]()
   users*: Table[cstring, User] = initTable[cstring, User]()
 
-proc getTable*[T](db: IndexedDB, dbStore: cstring, dbOptions: IDBOptions): Future[Table[cstring, T]] {.async.} =
+proc getTable*[T](db: IndexedDB, dbStore: cstring, dbOptions = IDBOptions(keyPath: "id")): Future[Table[cstring, T]] {.async.} =
   ## Gets objects from a given IndexedDB location and store in a Table.
   result = initTable[cstring, T]()
   try:
@@ -30,7 +31,7 @@ proc getTable*[T](db: IndexedDB, dbStore: cstring, dbOptions: IDBOptions): Futur
   except:
     logError "Failed to get stored objects."
 
-proc storeUser*[T](db: IndexedDB, obj: T, objs: var Table[cstring, T], dbStore: cstring, dbOptions: IDBOptions) {.async.} =
+proc storeTable*[T](db: IndexedDB, obj: T, objs: var Table[cstring, T], dbStore: cstring, dbOptions = IDBOptions(keyPath: "id")) {.async.} =
   ## Stores an object in a given store in IndexedDB.
   objs[obj.id] = obj
   try:

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -9,7 +9,7 @@ import
   pkg/lastfm,
   pkg/lastfm/auth,
   sources/[lb, lfm, utils],
-  views/share,
+  views/[share, db],
   types
 
 type
@@ -56,7 +56,7 @@ proc loadMirror(user: User) =
 proc validateMirror(username: cstring, service: Service) {.async.} =
   ## Validates and gets now playing for user.
   var user = newUser(username, service, selected = true)
-  mirrorUsers[user.userId] = user
+  mirrorUsers[user.id] = user
   try:
     case service:
     of Service.listenBrainzService:
@@ -111,7 +111,7 @@ proc serviceToggle: Vnode =
     input(`type` = "checkbox", id = "service-switch", class = "toggle")
     span(id = "service-slider", class = "slider")
 
-proc validateLBToken(token: cstring, userId: cstring = "", newUser = true) {.async.} =
+proc validateLBToken(token: cstring, id: cstring = "", newUser = true) {.async.} =
   ## Validates a given ListenBrainz token and stores the user.
   lbClient = newAsyncListenBrainz()
   let res = await lbClient.validateToken($token)
@@ -127,9 +127,9 @@ proc validateLBToken(token: cstring, userId: cstring = "", newUser = true) {.asy
     else:
       clientErrorMessage = "Token no longer valid!"
       try:
-        discard db.delete(clientUsersDbStore, userId, dbOptions)
+        discard db.delete(clientUsersDbStore, id, IDBOptions(keyPath: "id"))
       except:
-        clientUsers.del(userId)
+        clientUsers.del(id)
     redraw()
   serviceView = ServiceView.selection
 
@@ -148,9 +148,9 @@ proc validateFMSession(user: User, newUser = true) {.async.} =
       clientErrorMessage = "Session no longer valid!"
       # maybe? serviceView = ServiceView.selection
       try:
-        discard db.delete(clientUsersDbStore, user.userId, dbOptions)
+        discard db.delete(clientUsersDbStore, user.id, IDBOptions(keyPath: "id"))
       except:
-        clientUsers.del(user.userId)
+        clientUsers.del(user.id)
     redraw()
 
 proc renderUsers(storedUsers: var Table[cstring, User], userDbStore: cstring, mirror = false): Vnode =
@@ -159,34 +159,34 @@ proc renderUsers(storedUsers: var Table[cstring, User], userDbStore: cstring, mi
     serviceIconId: cstring
     buttonClass: cstring
   result = buildHtml(tdiv(id = "stored-users")):
-    for userId, user in storedUsers.pairs:
+    for id, user in storedUsers.pairs:
       buttonClass = "row"
       if user.selected:
         buttonClass = buttonClass & " selected"
-      button(id = userId, class = buttonClass, username = user.username, service = cstring $user.service):
+      button(id = id, class = buttonClass, username = user.username, service = cstring $user.service):
         serviceIconId = cstring $user.service & "-icon"
         tdiv(id = serviceIconId, class = "service-icon")
         text user.username
         proc onclick(ev: Event; n: VNode) =
-          let userId = n.id
-          if storedUsers[userId].selected:
-            storedUsers[userId].selected = false
-            discard db.storeUser(storedUsers[userId], storedUsers, userDbStore)
+          let id = n.id
+          if storedUsers[id].selected:
+            storedUsers[id].selected = false
+            discard db.storeUser(storedUsers[id], storedUsers, userDbStore)
           else:
             if mirror:
               let selectedIds = getSelectedIds(mirrorUsers)
               if selectedIds.len > 0:
                 storedUsers[selectedIds[0]].selected = false
-              storedUsers[userId].selected = true
-              discard db.storeUser(storedUsers[userId], storedUsers, userDbStore)
+              storedUsers[id].selected = true
+              discard db.storeUser(storedUsers[id], storedUsers, userDbStore)
             else:
-              storedUsers[userId].selected = true
-              case storedUsers[userId].service
+              storedUsers[id].selected = true
+              case storedUsers[id].service
               of Service.listenBrainzService:
                 serviceView = ServiceView.loading
-                discard validateLBToken(storedUsers[userId].token, storedUsers[userId].userId, newUser = false)
+                discard validateLBToken(storedUsers[id].token, storedUsers[id].id, newUser = false)
               of Service.lastFmService:
-                discard validateFMSession(storedUsers[userId], newUser = false)
+                discard validateFMSession(storedUsers[id], newUser = false)
 
 proc onLBTokenEnter(ev: Event; n: VNode) =
   ## Callback to validate a ListenBrainz token.

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -1,3 +1,7 @@
+## Home view module
+## Manages the home view for the web app, onboarding users to the mirror page.
+##
+
 {.experimental: "overloadableEnums".}
 
 import
@@ -37,7 +41,7 @@ var
 proc getUsers(db: IndexedDB, view: var ModalView, storedUsers: var Table[cstring, User], dbStore: cstring) {.async.} =
   ## Gets client users from IndexedDB, stores them in `storedClientUsers`, and sets the `OnboardView` if there are any existing users.
   try:
-    let users = await db.getUsers(dbStore)
+    let users = await db.getTable(dbStore, IDBOptions(keyPath: "userId"))
     if users.len != 0:
       storedUsers = users
       view = ModalView.returningUser

--- a/src/views/mirror.nim
+++ b/src/views/mirror.nim
@@ -1,3 +1,7 @@
+## Mirror view module
+## Manages the mirror view for the web app, handling mirroring of users.
+##
+
 import
   std/[dom, times, options, asyncjs, sequtils, strutils, uri, tables],
   pkg/karax/[karax, karaxdsl, vdom, jstrutils],

--- a/src/views/mirror.nim
+++ b/src/views/mirror.nim
@@ -3,7 +3,7 @@ import
   pkg/karax/[karax, karaxdsl, vdom, jstrutils],
   pkg/jsony,
   sources/[lb, lfm, utils],
-  home, share, types
+  home, db, share, types
 
 type
   MirrorView = enum
@@ -166,7 +166,7 @@ proc mirror*(username: cstring, service: Service): Vnode =
   if mirrorUsers.hasKey(mirrorUserId):
     let clientUserIds = getSelectedIds(clientUsers)
     if clientUserIds.len > 0:
-      if mirrorUsers[mirrorUserId].userId in clientUserIds:
+      if mirrorUsers[mirrorUserId].id in clientUserIds:
         mirrorToggle = false
       mirrorView = MirrorView.mirroring
     case mirrorUsers[mirrorUserId].service:
@@ -194,9 +194,9 @@ proc mirror*(username: cstring, service: Service): Vnode =
 proc getMirrorUser(username: cstring, service: Service) {.async.} =
   ## Gets the mirror user from the database, if they aren't in the database, they are initialised
   mirrorUsers = await db.getUsers(mirrorUsersDbStore)
-  let userId: cstring = cstring($service) & ":" & username
-  if userId in mirrorUsers:
-    mirrorUsers[mirrorUserId] = mirrorUsers[userId]
+  let id: cstring = cstring($service) & ":" & username
+  if id in mirrorUsers:
+    mirrorUsers[mirrorUserId] = mirrorUsers[id]
     let preMirror = not mirrorToggle
     case mirrorUsers[mirrorUserId].service:
     of Service.listenBrainzService:

--- a/src/views/share.nim
+++ b/src/views/share.nim
@@ -1,3 +1,7 @@
+## Shared view module
+## This module holds shared functions and globals to be used across the frontend.
+##
+
 import
   std/[asyncjs, jsffi, tables, sugar],
   pkg/karax/[karaxdsl, vdom],

--- a/src/views/share.nim
+++ b/src/views/share.nim
@@ -3,12 +3,9 @@
 ##
 
 import
-  std/[asyncjs, jsffi, tables, sugar],
   pkg/karax/[karaxdsl, vdom],
-  pkg/nodejs/jsindexeddb,
   pkg/[listenbrainz, lastfm],
-  sources/[lfm, utils],
-  types
+  sources/lfm
 
 type
   ClientView* = enum

--- a/src/views/share.nim
+++ b/src/views/share.nim
@@ -6,10 +6,6 @@ import
   sources/[lfm, utils],
   types
 
-const
-  clientUsersDbStore*: cstring = "clientUsers"
-  mirrorUsersDbStore*: cstring = "mirrorUsers"
-
 type
   ClientView* = enum
     homeView, mirrorView, loadingView, errorView
@@ -18,36 +14,7 @@ var
   globalView*: ClientView = ClientView.homeView
   fmClient*: AsyncLastFM = newAsyncLastFM(apiKey, apiSecret)
   lbClient*: AsyncListenBrainz = newAsyncListenBrainz()
-  db*: IndexedDB = newIndexedDB()
-  dbOptions*: IDBOptions = IDBOptions(keyPath: "userId")
-  clientUsers*: Table[cstring, User] = initTable[cstring, User]()
-  mirrorUsers*: Table[cstring, User] = initTable[cstring, User]()
   clientErrorMessage*, mirrorErrorMessage*: cstring = ""
-
-proc getSelectedIds*(users: Table[cstring, User]): seq[cstring] =
-  result = collect:
-    for userId, user in users:
-      if user.selected:
-        userId
-
-proc getUsers*(db: IndexedDB, dbStore: cstring, dbOptions: IDBOptions = dbOptions): Future[Table[cstring, User]] {.async.} =
-  ## Gets users from a given IndexedDB store.
-  result = initTable[cstring, User]()
-  try:
-    let objStore = await getAll(db, dbStore, dbOptions)
-    if not objStore.isNil:
-      result = collect:
-        for user in to(objStore, seq[User]): {user.userId: user}
-  except:
-    logError "Failed to get stored users."
-
-proc storeUser*(db: IndexedDB, user: User, users: var Table[cstring, User], dbStore: cstring, dbOptions: IDBOptions = dbOptions) {.async.} =
-  ## Stores a user in a given store in IndexedDB.
-  users[user.userId] = user
-  try:
-    discard put(db, dbStore, toJs user, dbOptions)
-  except:
-    logError "Failed to store users."
 
 proc errorModal*(message: cstring): Vnode =
   ## Render a div with a given error message

--- a/tests/tLbSource.nim
+++ b/tests/tLbSource.nim
@@ -88,6 +88,6 @@ suite "ListenBrainz source":
 
     # # Cannot be tested outside JS backend
     # test "Submit mirror queue":
-    #   var user = newUser(userId = username, services = [Service.listenBrainzService: newServiceUser(Service.listenBrainzService, username), Service.lastFmService: newServiceUser(Service.lastFmService)])
+    #   var user = newUser(id = username, services = [Service.listenBrainzService: newServiceUser(Service.listenBrainzService, username), Service.lastFmService: newServiceUser(Service.lastFmService)])
     #   user.listenHistory = @[newListen("track 1", "artist")]
     #   discard lb.submitMirrorQueue(user)

--- a/tests/tLbSource.nim
+++ b/tests/tLbSource.nim
@@ -26,9 +26,9 @@ suite "ListenBrainz source":
 
     test "Convert `seq[Listen]` to `seq[APIListen]` with `toMirror = true`":
       let
-        listens = @[newListen(cstring trackName, cstring artistName, listenedAt = listenedAt, mirrored = some false, preMirror = some false), newListen(cstring trackName, cstring artistName, listenedAt = listenedAt, mirrored = some true, preMirror = some false)]
+        listens = @[newListen(cstring trackName, cstring artistName, listenedAt = listenedAt), newListen(cstring trackName, cstring artistName, listenedAt = listenedAt)]
         apiListens = @[newAPIListen(listenedAt = listenedAt, trackMetadata = newTrackMetadata(trackName, artistName))]
-        newAPIListens = to(listens, toMirror = true)
+        newAPIListens = to(listens)
       check newAPIListens[0] == apiListens[0]
 
     test "Convert `Listen` to `APIListen` to `Listen`":
@@ -41,9 +41,8 @@ suite "ListenBrainz source":
     test "Convert `APIListen` to `Listen`":
       let
         apiListen = newAPIListen(trackMetadata = newTrackMetadata(trackName, artistName))
-        preMirror = some true
-        listen = newListen(cstring trackName, cstring artistName, preMirror = preMirror)
-        newListen = to(apiListen, preMirror)
+        listen = newListen(cstring trackName, cstring artistName)
+        newListen = to(apiListen)
       check listen == newListen
 
     test "Convert `seq[APIListen]` to `seq[Listen]`":
@@ -56,8 +55,7 @@ suite "ListenBrainz source":
     test "Convert `APIListen` to `Listen` to `APIListen`":
       let
         apiListen = newAPIListen(trackMetadata = newTrackMetadata(trackName, artistName))
-        preMirror = some true
-        listen = to(apiListen, preMirror)
+        listen = to(apiListen)
         newAPIListen = to listen
       check apiListen == newAPIListen
 
@@ -68,10 +66,10 @@ suite "ListenBrainz source":
         username = cstring os.getEnv("LISTENBRAINZ_USER")
 
     test "Get now playing":
-      let nowPlaying = waitFor lb.getNowPlaying(username, preMirror = false)
+      let nowPlaying = waitFor lb.getNowPlaying(username)
 
     test "Get recent tracks":
-      let recentTracks = waitFor lb.getRecentTracks(username, preMirror = false)
+      let recentTracks = waitFor lb.getRecentTracks(username)
       check recentTracks.len == 100
 
     test "Initialise user":
@@ -88,8 +86,8 @@ suite "ListenBrainz source":
     #   discard lb.pageUser(user, endInt, inc)
     #   check endInt == 20
 
-    ## Cannot be tested outside JS backend
+    # # Cannot be tested outside JS backend
     # test "Submit mirror queue":
     #   var user = newUser(userId = username, services = [Service.listenBrainzService: newServiceUser(Service.listenBrainzService, username), Service.lastFmService: newServiceUser(Service.lastFmService)])
-    #   user.listenHistory = @[newListen("track 1", "artist", preMirror = some false, mirrored = some false)]
+    #   user.listenHistory = @[newListen("track 1", "artist")]
     #   discard lb.submitMirrorQueue(user)

--- a/tests/tLfmSource.nim
+++ b/tests/tLfmSource.nim
@@ -96,6 +96,6 @@ suite "Last.FM source":
 
     ## Cannot be tested outside JS backend
     # test "Submit mirror queue":
-    #   var user = newUser(userId = username, services = [Service.listenBrainzService: newServiceUser(Service.listenBrainzService, username), Service.lastFmService: newServiceUser(Service.lastFmService)])
+    #   var user = newUser(id = username, services = [Service.listenBrainzService: newServiceUser(Service.listenBrainzService, username), Service.lastFmService: newServiceUser(Service.lastFmService)])
     #   user.listenHistory = @[newListen("track 1", "artist")]
     #   discard lb.submitMirrorQueue(user)

--- a/tests/tPure.nim
+++ b/tests/tPure.nim
@@ -1,0 +1,27 @@
+import std/[unittest, options]
+import ../src/types
+import ../src/sources/pure
+
+suite "Queue Filter":
+
+  test "Listen newer than latestListenTs with none lastSubmissionTs":
+    let
+      listen = newListen(cstring "track", cstring "artist", listenedAt = some 1)
+      latestListenTs = some 0
+      lastSubmissionTs = none int
+    check queueFilter(listen, latestListenTs, lastSubmissionTs)
+
+  test "Listen newer than latestListenTs but not lastSubmissionTs":
+    let
+      listen = newListen(cstring "track", cstring "artist", listenedAt = some 1)
+      latestListenTs = some 0
+      lastSubmissionTs = some 1
+    check queueFilter(listen, latestListenTs, lastSubmissionTs) == false
+
+  test "Listen with no listenedAt property":
+    let
+      listen = newListen(cstring "track", cstring "artist")
+      latestListenTs = some 0
+      lastSubmissionTs = some 0
+    expect IOError:
+      discard queueFilter(listen, latestListenTs, lastSubmissionTs)


### PR DESCRIPTION
This refactor will store listen history and the mirror submission queue in separate fields in the User object, to eventually enable mirroring to multiple accounts.



TODO:
 - [x] Add update queue proc
 - [x] Refactor update user proc
 - [ ] Implement `Client` and new listen store in the frontend (find out where to apply updateQueue proc) 